### PR TITLE
Fix update_subscription inability to report failure state

### DIFF
--- a/decoder/src/decoder.c
+++ b/decoder/src/decoder.c
@@ -231,12 +231,13 @@ int update_subscription(pkt_len_t pkt_len, subscription_update_packet_t *update)
             decoder_status.subscribed_channels[i].end_timestamp = update->end_timestamp;
             break;
         }
-        // If we do not have any room for more subscriptions
-        if (i == MAX_CHANNEL_COUNT) {
-            STATUS_LED_RED();
-            print_error("Failed to update subscription - max subscriptions installed\n");
-            return -1;
-        }
+    }
+
+    // If we do not have any room for more subscriptions
+    if (i == MAX_CHANNEL_COUNT) {
+        STATUS_LED_RED();
+        print_error("Failed to update subscription - max subscriptions installed\n");
+        return -1;
     }
 
     flash_simple_erase_page(FLASH_STATUS_ADDR);


### PR DESCRIPTION
Because the condition i==MAX_CHANNEL_COUNT was inside of the for loop, the for loop would terminate when i==MAX_CHANNEL_COUNT, meaning the if statement wouldn't actually be run.

By moving the check outside the loop body, it will now succesfully detect and report oversubscription :)