### PR TITLE
Fix README Linux decoder Docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ directory.
 ```bash
 cd <example_root>/decoder
 docker build -t decoder .
-docker run --rm -v ./build_out:/out -v ./:/decoder -v ../secrets:/secrets -e DECODER_ID=0xdeadbeef decoder
+docker run --rm -v ./build_out:/out -v ./:/decoder -v ./../secrets:/secrets -e DECODER_ID=0xdeadbeef decoder
 ```
 
 ### PowerShell:


### PR DESCRIPTION
Original command uses invalid command because docker doesn't accept `../` for the `-v` switch in this case. Changed to `./../`, which docker accepts.