### PR TITLE
Fix ACK mishandling for specifically sized packets

### DIFF
--- a/decoder/src/host_messaging.c
+++ b/decoder/src/host_messaging.c
@@ -158,8 +158,8 @@ int write_packet(msg_type_t type, const void *buf, uint16_t len) {
     // If there is data to write, write it
     if (len > 0) {
         result = write_bytes(buf, len, type != DEBUG_MSG);
-        // If we still need to ACK the last block
-        if (len % 256 && type != DEBUG_MSG && read_ack() < 0) {
+        // If we still need to ACK the last block (write_bytes does not handle the final ACK)
+        if (type != DEBUG_MSG && read_ack() < 0) {
             return -1;
         }
     }
@@ -198,8 +198,8 @@ int read_packet(msg_type_t* cmd, void *buf, uint16_t *len) {
                 return -1;
             }
         }
-        if (header.len && header.len % 256) {
-            if (write_ack() < 0) { // ACK the final block
+        if (header.len) {
+            if (write_ack() < 0) { // ACK the final block (not handled by read_bytes)
                 return -1;
             }
         }


### PR DESCRIPTION
The `write_bytes` and `read_bytes` functions are designed to handle intermediate ACKs for large packets, while leaving the final ACK of the body to the caller. The `write_packet` and `read_packet` functions, however, assume that for packets with a length divisible by 256 that the bytes functions will handle the final ACK, leading to either forgetting to handle an ACK or forgetting to send an ACK. Both of these cause problems but can be fixed by simply removing the errant check and unconditionally handling the final ACK in the packet functions as was intended.