### PR TITLE
Buffer overflow bug in decoder.

### DIFF
--- a/decoder/inc/host_messaging.h
+++ b/decoder/inc/host_messaging.h
@@ -51,7 +51,7 @@ typedef struct {
  * 
  *  @return 0 on success. A negative value on error.
 */
-int write_hex(msg_type_t type, const void *buf, size_t len);
+int write_hex(msg_type_t type, const void *buf, size_t len, uint16_t buffer_size);
 
 /** @brief Send a message to the host, expecting an ack after every 256 bytes.
  * 
@@ -61,7 +61,7 @@ int write_hex(msg_type_t type, const void *buf, size_t len);
  * 
  *  @return 0 on success. A negative value on failure.
 */
-int write_packet(msg_type_t type, const void *buf, uint16_t len);
+int write_packet(msg_type_t type, const void *buf, uint16_t len, uint16_t buffer_size);
 
 /** @brief Reads a packet from console UART.
  * 
@@ -71,16 +71,17 @@ int write_packet(msg_type_t type, const void *buf, uint16_t len);
  * 
  *  @return 0 on success, a negative number on failure
 */
-int read_packet(msg_type_t* cmd, void *buf, uint16_t *len);
+int read_packet(msg_type_t* cmd, void *buf, uint16_t *len, uint16_t buffer_size);
+
 
 // Macro definitions to print the specified format for error messages
-#define print_error(msg) write_packet(ERROR_MSG, msg, strlen(msg))
+#define print_error(msg) write_packet(ERROR_MSG, msg, strlen(msg), strlen(msg))
 
 // Macro definitions to print the specified format for debug messages
-#define print_debug(msg) write_packet(DEBUG_MSG, msg, strlen(msg))
-#define print_hex_debug(msg, len) write_hex(DEBUG_MSG, msg, len)
+#define print_debug(msg) write_packet(DEBUG_MSG, msg, strlen(msg), strlen(msg))
+#define print_hex_debug(msg, len) write_hex(DEBUG_MSG, msg, len, len)
 
 // Macro definitions to write ack message
-#define write_ack() write_packet(ACK_MSG, NULL, 0)
+#define write_ack() write_packet(ACK_MSG, NULL, 0, 0)
 
 #endif

--- a/decoder/src/decoder.c
+++ b/decoder/src/decoder.c
@@ -197,7 +197,7 @@ int list_channels() {
     len = sizeof(resp.n_channels) + (sizeof(channel_info_t) * resp.n_channels);
 
     // Success message
-    write_packet(LIST_MSG, &resp, len);
+    write_packet(LIST_MSG, &resp, len, sizeof(resp));
     return 0;
 }
 
@@ -243,7 +243,7 @@ int update_subscription(pkt_len_t pkt_len, subscription_update_packet_t *update)
     flash_simple_erase_page(FLASH_STATUS_ADDR);
     flash_simple_write(FLASH_STATUS_ADDR, &decoder_status, sizeof(flash_entry_t));
     // Success message with an empty body
-    write_packet(SUBSCRIBE_MSG, NULL, 0);
+    write_packet(SUBSCRIBE_MSG, NULL, 0, 0);
     return 0;
 }
 
@@ -272,7 +272,7 @@ int decode(pkt_len_t pkt_len, frame_packet_t *new_frame) {
         print_debug("Subscription Valid\n");
         /* The reference design doesn't need any extra work to decode, but your design likely will.
         *  Do any extra decoding here before returning the result to the host. */
-        write_packet(DECODE_MSG, new_frame->data, frame_size);
+        write_packet(DECODE_MSG, new_frame->data, frame_size, sizeof(output_buf));
         return 0;
     } else {
         STATUS_LED_RED();
@@ -388,7 +388,7 @@ int main(void) {
 
         STATUS_LED_GREEN();
 
-        result = read_packet(&cmd, uart_buf, &pkt_len);
+        result = read_packet(&cmd, uart_buf, &pkt_len, sizeof(uart_buf));
 
         if (result < 0) {
             STATUS_LED_ERROR();

--- a/decoder/src/host_messaging.c
+++ b/decoder/src/host_messaging.c
@@ -103,7 +103,9 @@ int write_bytes(const void *buf, uint16_t len, bool should_ack) {
  * 
  *  @return 0 on success. A negative value on error.
 */
-int write_hex(msg_type_t type, const void *buf, size_t len) {
+int write_hex(msg_type_t type, const void *buf, size_t len, uint16_t buffer_size) {
+
+
     msg_header_t hdr;
     int i;
 
@@ -138,7 +140,11 @@ int write_hex(msg_type_t type, const void *buf, size_t len) {
  * 
  *  @return 0 on success. A negative value on failure.
 */
-int write_packet(msg_type_t type, const void *buf, uint16_t len) {
+int write_packet(msg_type_t type, const void *buf, uint16_t len, uint16_t buffer_size) {
+    if (len > buffer_size) {
+        return -1;
+    }
+
     msg_header_t hdr;
     int result;
 
@@ -175,7 +181,7 @@ int write_packet(msg_type_t type, const void *buf, uint16_t len) {
  * 
  *  @return 0 on success, a negative number on failure
 */
-int read_packet(msg_type_t* cmd, void *buf, uint16_t *len) {
+int read_packet(msg_type_t* cmd, void *buf, uint16_t *len, uint16_t buffer_size) {
     msg_header_t header = {0};
 
     // cmd must be a valid pointer
@@ -188,6 +194,11 @@ int read_packet(msg_type_t* cmd, void *buf, uint16_t *len) {
     *cmd = header.cmd;
 
     if (len != NULL) {
+        if (header.len > buffer_size) {
+            len = NULL;
+            return -1;
+        }
+        
         *len = header.len;
     }
 


### PR DESCRIPTION
Found bug that allowed users to read and write arbitrary data to memory outside of designated buffer. We fixed this by passing the buffer size to the read and write functions and returning early if the length of the incoming buffer is larger than the output buffer.

~ University of South Alabama