### PR TITLE
Tool bugfixes

### DIFF
--- a/tools/ectf25/utils/stress_test.py
+++ b/tools/ectf25/utils/stress_test.py
@@ -157,7 +157,7 @@ def parse_args():
 
     decode_parser = subparsers.add_parser("decode", help="Test the decoder")
     decode_parser.set_defaults(tester=test_decoder)
-    decode_parser.set_defaults(threshold=100.0)
+    decode_parser.set_defaults(threshold=10.0)
     decode_parser.add_argument(
         "port",
         help="Serial port to the Decoder (See https://rules.ectf.mitre.org/2025/getting_started/boot_reference for platform-specific instructions)",

--- a/tools/ectf25/utils/tester.py
+++ b/tools/ectf25/utils/tester.py
@@ -95,7 +95,7 @@ def json_gen(args) -> Iterator[tuple[int, bytes, int]]:
 
                 # use real timestamp if --real-ts arg was provided
                 if args.real_ts:
-                    timestamp = time.time_ns() / 1000
+                    timestamp = time.time_ns() // 1000
 
                 # yield values to outer loop
                 yield channel, data.encode(), timestamp


### PR DESCRIPTION
- Fix timestamp being a non-int in tester.py
- Correct stress_test.py default decode FPS threshold to match spec