### PR TITLE
Fix README.md build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,13 +205,13 @@ options:
 #### Linux
 
 ```bash
-python -m ectf25.utils.flash ./build_out/max78000.bin /dev/tty.usbmodem11302
+python -m ectf25.utils.flash ./decoder/build_out/max78000.bin /dev/tty.usbmodem11302
 ```
 
 #### PowerShell
 
 ```
-python -m ectf25.utils.flash .\build_out\max78000.bin COM12
+python -m ectf25.utils.flash .\decoder\build_out\max78000.bin COM12
 ```
 
 ## Host Tools
@@ -319,13 +319,13 @@ options:
 #### Linux
 
 ```bash
-python -m ectf25.utils.tester --port /dev/tty.usbmodem11302 -s ./secrets.json rand -c 1 -f 64
+python -m ectf25.utils.tester --port /dev/tty.usbmodem11302 -s secrets/secrets.json rand -c 1 -f 64
 ```
 
 #### PowerShell
 
 ```
-python -m ectf25.utils.tester --port COM12 -s .\secrets\secrets.json rand -c 1 -f 64
+python -m ectf25.utils.tester --port COM12 -s secrets\secrets.json rand -c 1 -f 64
 ```
 
 ## Running the Satellite and Encoder


### PR DESCRIPTION
`docker run --rm -v ./build_out:/out -v ./:/decoder -v ./../secrets:/secrets -e DECODER_ID=0xdeadbeef decoder` puts the build_out directory in the same directory as the decoder directory. However the later flashing command `python -m ectf25.utils.flash ./build_out/max78000.bin /dev/tty.usbmodem11302` doesn't specify directory. Assuming it is running in the root directory of the repo this command will fail. This is a simple fix by just changing the docker run command to place build_out in the previous directory. Or the flash command should be updated to either cd into the decoder directory or just include the directory in the command itself so it would be `python -m ectf25.utils.flash ./decoder/build_out/max78000.bin /dev/tty.usbmodem11302` . Also `python -m ectf25.utils.tester --port /dev/tty.usbmodem11302 -s ./secrets.json rand -c 1 -f 64` includes a similar problem where it should be referring to ./secrets/secrets.json  not ./secrets.json. 