### PR TITLE
Fix units in stress test

### DIFF
--- a/tools/ectf25/utils/stress_test.py
+++ b/tools/ectf25/utils/stress_test.py
@@ -144,7 +144,7 @@ def parse_args():
 
     encode_parser = subparsers.add_parser("encode", help="Test the encoder")
     encode_parser.set_defaults(tester=test_encoder)
-    encode_parser.set_defaults(threshold=1_000.0)
+    encode_parser.set_defaults(threshold=64_000.0)
     encode_parser.add_argument(
         "secrets", type=argparse.FileType("rb"), help="Path to the secrets file"
     )
@@ -157,7 +157,7 @@ def parse_args():
 
     decode_parser = subparsers.add_parser("decode", help="Test the decoder")
     decode_parser.set_defaults(tester=test_decoder)
-    decode_parser.set_defaults(threshold=10.0)
+    decode_parser.set_defaults(threshold=640.0)
     decode_parser.add_argument(
         "port",
         help="Serial port to the Decoder (See https://rules.ectf.mitre.org/2025/getting_started/boot_reference for platform-specific instructions)",


### PR DESCRIPTION
The stress tester has a bug which would allow implementations that are much slower than the throughput requirement minimums. The core issue is that the threshold value is in bytes/second, while the listed requirements are in frames/second. To fix, the threshold value should 64 times what it currently is, because each frame is 64 bytes.

Before:

To demonstrate, I added an `MXC_DELAY` of 1000/9 milliseconds to the decoder function, ensuring that it can never meet the throughput requirement of 10 frames/second.

```c
print_debug("Checking subscription\n");
if (is_subscribed(channel)) {
    print_debug("Subscription Valid\n");
    MXC_Delay(MXC_DELAY_MSEC(1000/9)); // <---- added this delay here
    /* The reference design doesn't need any extra work to decode, but your design likely will.
    *  Do any extra decoding here before returning the result to the host. */
    write_packet(DECODE_MSG, new_frame->data, frame_size);
    return 0;
} else {
```

```
$ python -m ectf25.utils.stress_test -t 6400 decode /dev/ttyACM0 frames/custom.json
...
2025-01-30 16:38:28.449 | INFO     | ectf25.utils.decoder:get_msg:262 - Got DEBUG: b'Checking subscription\n'
2025-01-30 16:38:28.450 | DEBUG    | ectf25.utils.decoder:try_parse:218 - Found header MessageHdr(opcode=<Opcode.DEBUG: 71>, len=19)
2025-01-30 16:38:28.451 | DEBUG    | ectf25.utils.decoder:get_raw_msg:243 - Read block b'Subscription Valid\n'
2025-01-30 16:38:28.451 | DEBUG    | ectf25.utils.decoder:get_raw_msg:247 - Got message Message(opcode=<Opcode.DEBUG: 71>, body=b'Subscription Valid\n')
2025-01-30 16:38:28.451 | INFO     | ectf25.utils.decoder:get_msg:262 - Got DEBUG: b'Subscription Valid\n'
2025-01-30 16:38:28.561 | DEBUG    | ectf25.utils.decoder:try_parse:218 - Found header MessageHdr(opcode=<Opcode.DECODE: 68>, len=64)
2025-01-30 16:38:28.569 | DEBUG    | ectf25.utils.decoder:get_raw_msg:243 - Read block b'\xeet-\x88op\x84"j\xdes0C\\U=\xbb\xf7u\xedG\xabBy\xd49\x8cRVA\xd7k\xed5=\xb3\xc3\xc1\xaf\xad\xba?=A2\x99p\x9e\x05\xad\xca\xc5\xb3\x8c\t\x8e!\x8b\x980\xf0\x0b\x92!'
2025-01-30 16:38:28.570 | DEBUG    | ectf25.utils.decoder:get_raw_msg:247 - Got message Message(opcode=<Opcode.DECODE: 68>, body=b'\xeet-\x88op\x84"j\xdes0C\\U=\xbb\xf7u\xedG\xabBy\xd49\x8cRVA\xd7k\xed5=\xb3\xc3\xc1\xaf\xad\xba?=A2\x99p\x9e\x05\xad\xca\xc5\xb3\x8c\t\x8e!\x8b\x980\xf0\x0b\x92!')
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:13<00:00,  7.51it/s]
2025-01-30 16:38:28.572 | SUCCESS  | __main__:test_decoder:120 - Throughput sufficient: 0.48 KBps > 0.01 KBps
```

It reports as having 48 times the minimum throughput.

After:

```
$ python -m ectf25.utils.stress_test -t 6400 decode /dev/ttyACM0 frames/custom.json
...
2025-01-30 16:41:56.928 | INFO     | ectf25.utils.decoder:get_msg:262 - Got DEBUG: b'Checking subscription\n'
2025-01-30 16:41:56.929 | DEBUG    | ectf25.utils.decoder:try_parse:218 - Found header MessageHdr(opcode=<Opcode.DEBUG: 71>, len=19)
2025-01-30 16:41:56.930 | DEBUG    | ectf25.utils.decoder:get_raw_msg:243 - Read block b'Subscription Valid\n'
2025-01-30 16:41:56.930 | DEBUG    | ectf25.utils.decoder:get_raw_msg:247 - Got message Message(opcode=<Opcode.DEBUG: 71>, body=b'Subscription Valid\n')
2025-01-30 16:41:56.930 | INFO     | ectf25.utils.decoder:get_msg:262 - Got DEBUG: b'Subscription Valid\n'
2025-01-30 16:41:57.041 | DEBUG    | ectf25.utils.decoder:try_parse:218 - Found header MessageHdr(opcode=<Opcode.DECODE: 68>, len=64)
2025-01-30 16:41:57.049 | DEBUG    | ectf25.utils.decoder:get_raw_msg:243 - Read block b'JD\\\xf8A\xd9)\xe2\xbf\x9c\x93Xq\xd3\xb7qJ\x80\xc6\xdfmn\xe7.\x18\x9c[\x9b\xaeW{\x8aiZ\xd5\xe1\x00\xd2X\xea7\x15g\x03l\x8c\xe0\\`\n0\xff\xcb\xa4^\xc6\xf5\x89o-d\xe5\xb4P'
2025-01-30 16:41:57.049 | DEBUG    | ectf25.utils.decoder:get_raw_msg:247 - Got message Message(opcode=<Opcode.DECODE: 68>, body=b'JD\\\xf8A\xd9)\xe2\xbf\x9c\x93Xq\xd3\xb7qJ\x80\xc6\xdfmn\xe7.\x18\x9c[\x9b\xaeW{\x8aiZ\xd5\xe1\x00\xd2X\xea7\x15g\x03l\x8c\xe0\\`\n0\xff\xcb\xa4^\xc6\xf5\x89o-d\xe5\xb4P')
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100/100 [00:13<00:00,  7.49it/s]
2025-01-30 16:41:57.050 | ERROR    | __main__:test_decoder:115 - Throughput too slow! 0.48 KBps < 0.64 KBps
```

The stress tester successfully reports that the design is too slow.

The encoder stress test had the same issue, which is also fixed in this PR.