### PR TITLE
Stress test fixes

### DIFF
--- a/tools/ectf25/utils/stress_test.py
+++ b/tools/ectf25/utils/stress_test.py
@@ -136,7 +136,7 @@ def parse_args():
     parser.add_argument(
         "--channels",
         "-c",
-        action="append",
+        nargs="+",
         type=int,
         default=[0, 1, 2, 3],
         help="Channels to randomly chose from (NOTE: 0 is broadcast)",

--- a/tools/ectf25/utils/stress_test.py
+++ b/tools/ectf25/utils/stress_test.py
@@ -99,10 +99,12 @@ def test_decoder(args):
     ]
 
     logger.info("Running stress test...")
+    total_frame_len = 0
     start = time.perf_counter()
     for frame in tqdm(frames):
         try:
-            decoder.decode(frame.data)
+            frame_data = decoder.decode(frame.data)
+            total_frame_len += len(frame_data)
         except Exception as e:
             logger.error(f"Errored on frame {frame}!")
             raise e
@@ -110,7 +112,7 @@ def test_decoder(args):
 
     # Check threshold
     kb_threshold = args.threshold / 1000
-    kb_throughput = args.test_size / total / 1000
+    kb_throughput = total_frame_len / total / 1000
     if kb_throughput < kb_threshold:
         logger.error(
             f"Throughput too slow! {kb_throughput:,.2f} KBps < {kb_threshold:,.2f} KBps"


### PR DESCRIPTION
Fixing a couple of minor bugs in stress_test.py

1. It computes the decode throughput using the value of the flag --test_size. When testing the decoder by loading a json, the amount of data is not necessarily equal to the value of the flag. If one omits the flag on the command line it defaults to a very large number, which gives a very high incorrect throughput. Fix: compute the total size of the decoded frames and use that as the numerator when computing throughput.
2. The --channel flag defaults to [0, 1, 2, 3] and is in 'append' mode. This means that putting --channel 0 on the command line doesn't restrict the generated frames to channel 0 only, it still uses the default value (you can add extra channels but can't remove 0,1,2,3). Fix: change action="append" to nargs="+"