### PR TITLE
Prevent stress_test from frequently generating duplicate frame timestamps

### DIFF
--- a/tools/ectf25/utils/stress_test.py
+++ b/tools/ectf25/utils/stress_test.py
@@ -35,13 +35,14 @@ def test_encoder(args):
     encoder = Encoder(args.secrets.read())
     nframes = math.ceil(args.test_size / args.frame_size)
     logger.info(f"Generating frames ({nframes:,} {args.frame_size}B frames)...")
+
     frames = [
         Frame(
             random.choice(args.channels),  # pick random channel
             random.randbytes(args.frame_size),  # generate random frame
-            time.time_ns() // 1000,  # generate microsecond timestamp
+            time.time_ns() + i,  # generate nanosecond timestamp, w/ slight increment to avoid duplicate timestamps
         )
-        for _ in range(nframes)
+        for i in range(nframes)
     ]
 
     logger.info("Running stress test...")


### PR DESCRIPTION
Because frame timestamps were generated all at once before any encoding occurred, the microsecond-level timestamp was frequently duplicated between succesive frames, leading to decoder failure w/ "non-atomic timestamp" messages.

This commit first
a) Makes the timestamp nano-second level precision and b) Adds an additional offset to each frame, as (at least on macOS) the time_ns() function only actually returns at a mcirosecond-level precision.

This PR was made by the University of Michigan ECTF team